### PR TITLE
chore(renovate): extend shared Go preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,5 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabled": true,
     "dependencyDashboard": false,
-    "extends": [
-        "config:recommended",
-        "github>jheddings/regula:golang"
-    ]
+    "extends": ["config:recommended", "github>jheddings/regula:golang"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabled": true,
     "dependencyDashboard": false,
-    "extends": ["config:base"]
+    "extends": [
+        "config:recommended",
+        "github>jheddings/regula:golang"
+    ]
 }


### PR DESCRIPTION
Points Renovate at the shared Go preset in [regula](https://github.com/jheddings/regula).

The preset groups `golang.org/x/**` modules. Those release in lockstep, so grouping them turns a burst of near-identical PRs into one.

Also replaces `config:base`, which is deprecated, with `config:recommended`.
